### PR TITLE
fix: install Puppet 5 instead of PC1

### DIFF
--- a/tortuga_kits/azureadapter_7_0_3/files/ubuntu_bootstrap.py.tmpl
+++ b/tortuga_kits/azureadapter_7_0_3/files/ubuntu_bootstrap.py.tmpl
@@ -59,7 +59,7 @@ def _isPackageInstalled(pkgName):
 
 
 def installPuppet(codename):
-    url = 'http://apt.puppetlabs.com/puppetlabs-release-pc1-%s.deb' % codename
+    url = 'http://apt.puppetlabs.com/puppet5-release-%s.deb' % codename
 
     bRepoInstalled = _isPackageInstalled('puppetlabs-release')
 

--- a/tortuga_kits/azureadapter_7_0_3/files/ubuntu_cloud_init.tmpl.yaml
+++ b/tortuga_kits/azureadapter_7_0_3/files/ubuntu_cloud_init.tmpl.yaml
@@ -15,8 +15,8 @@
 #cloud-config
 
 runcmd:
-  - ( cd /tmp; curl -O http://apt.puppetlabs.com/puppetlabs-release-pc1-xenial.deb )
-  - dpkg -i /tmp/puppetlabs-release-pc1-xenial.deb
+  - ( cd /tmp; curl -O http://apt.puppetlabs.com/puppet5-release-bionic.deb )
+  - dpkg -i /tmp/puppet5-release-bionic.deb
   - apt-get update
   - apt-get install -y puppet-agent
   - /opt/puppetlabs/bin/puppet agent --waitforcert 120 --server {{ installer }} --logdest /tmp/puppet_bootstrap.log --onetime


### PR DESCRIPTION
Fixes related to bootstrap of Ubuntu compute nodes.