### PR TITLE
Add resource adapter profile to insertnode_request for scalesets

### DIFF
--- a/src/tortuga/resourceAdapter/azureadapter/azureadapter.py
+++ b/src/tortuga/resourceAdapter/azureadapter/azureadapter.py
@@ -383,8 +383,9 @@ class AzureAdapter(ResourceAdapter):
             parameters['properties']['virtualMachineProfile']['eviction_policy'] = evictionPolicy
 
         insertnode_request = {
-                   'softwareProfile': softwareProfile,
-                   'hardwareProfile': hardwareProfile,
+            'softwareProfile': softwareProfile,
+            'hardwareProfile': hardwareProfile,
+            'resource_adapter_configuration': resourceAdapterProfile,
         }
         encrypted_insertnode_request = encrypt_insertnode_request(
                     self._cm.get_encryption_key(),


### PR DESCRIPTION
Add the name of the resource adapter profile to the insertnode_request so that when a node is created in a scaleset and it pings the tortuga REST API, it will provide its resource adapter profile name so that tortuga can load the proper configuration.

Tested in live Launch demo in Azure. Test method identical to that described in https://github.com/UnivaCorporation/tortuga-kit-gceadapter/pull/99.