### PR TITLE
Scaleset bugfixes

### DIFF
--- a/src/tortuga/resourceAdapter/azureadapter/azureadapter.py
+++ b/src/tortuga/resourceAdapter/azureadapter/azureadapter.py
@@ -746,6 +746,7 @@ class AzureAdapter(ResourceAdapter):
             internal_ip,
         )
 
+        vm_name = get_vm_name(node.name)
         node.instance = InstanceMapping(
             instance=nodeDetail['name'],
             instance_metadata=[

--- a/src/tortuga/resourceAdapter/azureadapter/azureadapter.py
+++ b/src/tortuga/resourceAdapter/azureadapter/azureadapter.py
@@ -413,7 +413,7 @@ class AzureAdapter(ResourceAdapter):
         :raises InvalidArgument:
         """
         self.create_scale_set(name,resourceAdapterProfile,hardwareProfile,
-            softwareProfile, minCount, maxCount, desiredCount)
+            softwareProfile, minCount, maxCount, desiredCount, adapter_args)
 
     def delete_scale_set(self,
               name: str,


### PR DESCRIPTION
* Call to `create_scale_set` method in `update_scale_set` resource adapter method was missing a required positional arg (`adapter_args`).
* Construction of an `InstanceMapping` object used an undefined `vm_name` variable. Used the `get_vm_name` helper function to construct `vm_name` from `node.name`.