### PR TITLE
Fix vm lookup during registration workflow

### DIFF
--- a/src/tortuga/resourceAdapter/azureadapter/azureadapter.py
+++ b/src/tortuga/resourceAdapter/azureadapter/azureadapter.py
@@ -706,8 +706,13 @@ class AzureAdapter(ResourceAdapter):
             'scale_set_name' in nodeDetail['metadata'] else None
         if scale_set_name == "":
             scale_set_name = None
-        
-        instance = self.__azure_get_vm(session, nodeDetail['name'], scale_set_name, instance_id)
+
+        instance = self.__azure_get_vm(
+            session,
+            get_vm_name(nodeDetail['name']),
+            scale_set_name,
+            instance_id
+        )
 
         if not instance:
             self._logger.warning(
@@ -1345,7 +1350,7 @@ insertnode_request = %(insertnode_request)s
             msrestazure.azure_exceptions.CloudError
         """
 
-        self._logger.debug('__azure_get_vm(): vm_name=[%s}]', vm_name)
+        self._logger.debug('__azure_get_vm(): vm_name=[%s]', vm_name)
 
         if scale_set_name is None:
             return session.compute_client.virtual_machines.get(


### PR DESCRIPTION
 When a VM tried to register, our attempt to look it up using the Azure cli used the FQDN rather than just the VM name. Fixed to use VM name. Not an issue for scale sets.

Includes commit from #110 - only new commit here is 88b4919.