### PR TITLE
Don't require bootstrap script

### DIFF
--- a/doc/tortuga-kit-azureadapter.md
+++ b/doc/tortuga-kit-azureadapter.md
@@ -454,6 +454,11 @@ The following Azure resource adapter configuration settings are
     This is the script run by [WALinuxAgent][] when VMs are initially
     booted.
 
+    Most configurations will want to set either this value or
+    `cloud_init_script_template`, but not all; as a result, these
+    settings are not required and we do not enforce that at least one
+    is set.
+
     **Note:** the official OpenLogic-provided CentOS VM images on Azure
     are [WALinuxAgent][] enabled, however do not enable the ability to
     launch a bootstrap script. A custom or alternative VM image with

--- a/src/tortuga/resourceAdapter/azureadapter/settings.py
+++ b/src/tortuga/resourceAdapter/azureadapter/settings.py
@@ -115,7 +115,6 @@ SETTINGS = {
                     'fully-qualified (does not start with a leading'
                     'forward slash), it is assumed the script path is '
                     '$TORTUGA_ROOT/config',
-        required=True,
         base_path='/opt/tortuga/config/',
         mutually_exclusive=['user_data_script_template'],
         overrides=['user_data_script_template'],
@@ -128,7 +127,6 @@ SETTINGS = {
                     'fully-qualified (ie. does not start with a leading '
                     'forward slash), it is assumed the script path is '
                     '$TORTUGA_ROOT/config',
-        required=True,
         base_path='/opt/tortuga/config/',
         mutually_exclusive=['cloud_init_script_template'],
         overrides=['cloud_init_script_template'],


### PR DESCRIPTION
Some configurations (high-scalability, for example) will not want to set a bootstrap script because the configuration has already been set up on the underlying image.

Includes commits from #111 - only new commit here is 7ed583d.