### PR TITLE
Add scaleset request validation

### DIFF
--- a/kit.json
+++ b/kit.json
@@ -3,5 +3,5 @@
   "version": "7.1.0",
   "iteration": "0",
   "description": "Azure resource adapter",
-  "requires_core": "7.1.0+005"
+  "requires_core": "7.1.0+006"
 }


### PR DESCRIPTION
Fail if scale set resource request includes an instance template name (Azure doesn't have them) or if it doesn't include both a hardware profile and software profile.

Includes commits from #112 - new commits here are:
* a06ea20
* b18b2b4