### PR TITLE
Modernize pip requirements and protect against large version changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-urllib3==1.24.2
-azure-cli==2.0.76
-colorama
-gevent
+azure-cli~=2.2.0
+colorama~=0.4.1
+gevent~=1.4.0
 msrestazure==0.6.2
-Jinja2
+Jinja2~=2.0


### PR DESCRIPTION
There are a few problems with the declared requirements for the Azure adapter:

1. It declares an unused dependency on `urllib3` (`urllib` and `urllib2` are used, but not `urllib3`)
1. It pins a release of `azure-cli` that is out-of-date. MSFT appears to have greatly lowered the release of cadence from `2.0.x` to `2.1.x` and `2.2.x`. We might as well use the currently supported release.
1. There is an alpha pre-release of Jinja2 3.0. I think we should avoid "accidentally" upgrading to 3.x. In practice code should probably be re-factored to use built-in templating since it's about 5 lines of code with direct equivalents in modern Python.
1. Similarly pin `gevent` on a recent release before 2.0 comes out.
1. Pin `colorama` in a manner compatible with rest of Tortuga / Azure ecosystem.

One can examine [Azure CLI Release Notes](https://github.com/MicrosoftDocs/azure-docs-cli/blob/master/docs-ref-conceptual/release-notes-azure-cli.md) for problems. I see the Storage Account defaulting to v2 vs v1 as a potential issue but, if it is one, we need to address it whether we like it or not.